### PR TITLE
Why https for local dev server?

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,8 +32,7 @@ module.exports = {
   mode: 'development',
 
   devServer: {
-    contentBase: path.resolve(__dirname, 'dist'),
-    https: true
+    contentBase: path.resolve(__dirname, 'dist')
   },
 
   plugins: [


### PR DESCRIPTION
When I tried to use this project, I kept getting this error:

> This page isn’t workinglocalhost didn’t send any data.
> ERR_EMPTY_RESPONSE

I luckily noticed this https in the config. But why would you leave this on? Is it because of your host? Do you use `https` for localhost during development?